### PR TITLE
Add manual PyPI publish workflow

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -41,7 +41,16 @@ jobs:
           run-id: ${{ inputs.build_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish to PyPI
+      - name: Publish to PyPI (API token)
+        if: ${{ secrets.PYPI_API_TOKEN != '' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Publish to PyPI (trusted publishing)
+        if: ${{ secrets.PYPI_API_TOKEN == '' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,0 +1,47 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_run_id:
+        description: "Run ID for the build_wheels workflow to pull artifacts from."
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: Publish wheels to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Download Linux wheels artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wheels-linux
+          path: dist
+          run-id: ${{ inputs.build_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download macOS wheels artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wheels-macos
+          path: dist
+          run-id: ${{ inputs.build_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Windows wheels artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wheels-windows
+          path: dist
+          run-id: ${{ inputs.build_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist


### PR DESCRIPTION
### Motivation

- Provide a manual way to publish previously-built wheel artifacts to PyPI from CI artifacts.
- Support publishing artifacts produced by the existing `build_wheels` workflow across Linux, macOS, and Windows.
- Allow selecting which build run to use by specifying a `build_run_id` at dispatch time.

### Description

- Add a new workflow file ` .github/workflows/publish_pypi.yml` that is triggered via `workflow_dispatch`.
- The workflow accepts a `build_run_id` input and downloads `wheels-linux`, `wheels-macos`, and `wheels-windows` artifacts using `actions/download-artifact@v4` with the given `run-id`.
- It publishes the collected packages from `dist` using `pypa/gh-action-pypi-publish@release/v1` with `packages-dir: dist`.
- The job runs on `ubuntu-latest` and requests `id-token: write` and `contents: read` permissions.

### Testing

- No automated tests were run because this is a workflow-only change and does not modify runtime code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb64757a8832482a4c4905a27d145)