### PR TITLE
add RNG seed support to RANSAC, bump version to 0.2

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -24,7 +24,7 @@ jobs:
         # to supply options, put them in 'env', like:
         env:
           CIBW_BEFORE_ALL_LINUX: yum install -y lapack-devel blas-devel gcc-gfortran
-          CIBW_BUILD: cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64 cp314-manylinux_x86_64
+          CIBW_BUILD: cp38-manylinux_x86_64 cp39-manylinux_x86_64 cp310-manylinux_x86_64 cp311-manylinux_x86_64 cp312-manylinux_x86_64 cp313-manylinux_x86_64 cp314-manylinux_x86_64
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel}"
 
       - uses: actions/upload-artifact@v4
@@ -58,7 +58,7 @@ jobs:
         env:
           CIBW_BEFORE_ALL: brew install openblas python
           CIBW_ARCHS_MACOS: x86_64 arm64
-          CIBW_BUILD: cp310-macosx_x86_64 cp310-macosx_arm64 cp311-macosx_x86_64 cp311-macosx_arm64 cp312-macosx_x86_64 cp312-macosx_arm64 cp313-macosx_x86_64 cp313-macosx_arm64 cp314-macosx_x86_64 cp314-macosx_arm64
+          CIBW_BUILD: cp38-macosx_x86_64 cp38-macosx_arm64 cp39-macosx_x86_64 cp39-macosx_arm64 cp310-macosx_x86_64 cp310-macosx_arm64 cp311-macosx_x86_64 cp311-macosx_arm64 cp312-macosx_x86_64 cp312-macosx_arm64 cp313-macosx_x86_64 cp313-macosx_arm64 cp314-macosx_x86_64 cp314-macosx_arm64
           CIBW_ENVIRONMENT_MACOS: CMAKE_OSX_ARCHITECTURES=$CIBW_ARCHS
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
       - uses: actions/upload-artifact@v4
@@ -88,7 +88,7 @@ jobs:
         env:
           CIBW_ARCHS_WINDOWS: AMD64
           CIBW_BEFORE_ALL_WINDOWS: vcpkg install openblas lapack --triplet x64-windows
-          CIBW_BUILD: cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64 cp314-win_amd64
+          CIBW_BUILD: cp38-win_amd64 cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64 cp314-win_amd64
           CIBW_ENVIRONMENT_WINDOWS: "VCPKG_ROOT=C:/vcpkg CMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
 
       - uses: actions/upload-artifact@v4

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ with open(path.join(this_directory, 'README.md')) as f:
 
 setup(
     name='pydegensac',
-    version='0.1.2',
+    version='0.2',
     author='Ondra Chum, Dmytro Mishkin',
     author_email='ducha.aiki@gmail.com',
     license='MIT',  

--- a/src/pydegensac/bindings.cpp
+++ b/src/pydegensac/bindings.cpp
@@ -23,7 +23,8 @@ py::tuple findHomography_(py::array_t<double>  x1y1_,
                           int max_iters,
                           int error_type,
                           bool sym_check_enable,
-                          double laf_coef) {
+                          double laf_coef,
+                          int seed) {
     // Get the data
     py::buffer_info buf1 = x1y1_.request();
     size_t NUM_TENTS = buf1.shape[0];
@@ -223,7 +224,8 @@ py::tuple findHomography_(py::array_t<double>  x1y1_,
                          0,
                          &resids,
                          HDS1,HDSi1,HDSidx1,
-                         SymCheck_th);
+                         SymCheck_th,
+                         seed);
 
 
 
@@ -262,7 +264,8 @@ py::tuple findFundamentalMatrix_(py::array_t<double>  x1y1_,
                                  int error_type,
                                  bool sym_check_enable,
                                  double laf_coef,
-                                 bool enable_degeneracy_check) {
+                                 bool enable_degeneracy_check,
+                                 int seed) {
     // Get the data
     py::buffer_info buf1 = x1y1_.request();
     size_t NUM_TENTS = buf1.shape[0];
@@ -440,7 +443,8 @@ py::tuple findFundamentalMatrix_(py::array_t<double>  x1y1_,
                          HinF,Ihptr,
                          EXFDS1,FDS1,FDSidx1,
                          SymCheck_th,
-                         (int)enable_degeneracy_check);
+                         (int)enable_degeneracy_check,
+                         seed);
 
 
     // Convert and store output
@@ -497,7 +501,8 @@ PYBIND11_PLUGIN(pydegensac) {
             py::arg("max_iters") = 10000,
             py::arg("error_type") = 0,
             py::arg("sym_check_enable") = 1,
-            py::arg("laf_coef") = 0);
+            py::arg("laf_coef") = 0,
+            py::arg("seed") = -1);
 
     m.def("findFundamentalMatrix_", &findFundamentalMatrix_, R"doc(some doc)doc",
           py::arg("x1y1"),
@@ -508,7 +513,8 @@ PYBIND11_PLUGIN(pydegensac) {
           py::arg("error_type") = 0,
           py::arg("sym_check_enable") = 1,
           py::arg("laf_coef") = 0,
-          py::arg("enable_degeneracy_check") = 1);
+          py::arg("enable_degeneracy_check") = 1,
+          py::arg("seed") = -1);
 
     return m.ptr();
 }

--- a/src/pydegensac/degensac/exp_ranF.c
+++ b/src/pydegensac/degensac/exp_ranF.c
@@ -1239,12 +1239,13 @@ int exp_ransacFcustom(double *u, int len, double th, double conf, int max_sam,
     return maxS.I;
 };
 
-int exp_ransacFcustomLAF(double *u, double *u_1, double *u_2,int len, double th,  double laf_coef,
+int exp_ransacFcustomLAF(double *u, double *u_1, double *u_2, int len, double th, double laf_coef,
                          double conf, int max_sam,
                          double *F, unsigned char * inl,
                          int * data_out, int do_lo, unsigned inlLimit, double **resids, double* H_best,
-                         int* Ih, exFDsPtr EXFDS1, FDsPtr FDS1, FDsidxPtr FDS1idx, double SymCheck_th, int enable_degen_check) {
-    unsigned seed;
+                         int* Ih, exFDsPtr EXFDS1, FDsPtr FDS1, FDsidxPtr FDS1idx, double SymCheck_th,
+                         int enable_degen_check, int seed) {
+    unsigned rand_seed;
 
     int *pool, no_sam, new_sam;  double *Z, *buffer, u7[6*7], H[3*3], FBest[3*3];
     int * bufferP;
@@ -1272,7 +1273,11 @@ int exp_ransacFcustomLAF(double *u, double *u_1, double *u_2,int len, double th,
     double *err_laf;
     int a;
 
-    srand(time(NULL)); //Mishkin - randomization
+    if (seed >= 0) {
+        srand((unsigned)seed);
+    } else {
+        srand(time(NULL)); //Mishkin - randomization
+    }
 
 #ifdef USE_QR
     double A[7*9], sol[2*9];
@@ -1326,18 +1331,18 @@ int exp_ransacFcustomLAF(double *u, double *u_1, double *u_2,int len, double th,
     f1 = sol;
     f2 = sol+9;
 
-    seed = rand();
+    rand_seed = rand();
 
     /*  srand(RAND_SEED++); */
     while(no_sam < max_sam) {
         no_sam ++;
 
-        srand(seed);
+        srand(rand_seed);
 
         rsampleT(Z, 9, pool, 7, len, A);
         loadSample(u, samidx, 7, 6, u7);
 
-        seed = rand();
+        rand_seed = rand();
         ////printf("Seed: %d\n",seed);
 
 

--- a/src/pydegensac/degensac/exp_ranF.h
+++ b/src/pydegensac/degensac/exp_ranF.h
@@ -69,9 +69,10 @@ Score exp_inFranicustom (double *u, int len, int *inliers, int ninl,
 #ifdef __cplusplus
 extern "C"
 #endif
-int exp_ransacFcustomLAF(double *u, double *u_1, double *u_2,int len, double th,  double laf_coef, double conf, int max_sam,
+int exp_ransacFcustomLAF(double *u, double *u_1, double *u_2, int len, double th, double laf_coef, double conf, int max_sam,
             double *F, unsigned char * inl,
-            int * data_out, int do_lo, unsigned inlLimit, double **resids, double* H_best, int* Ih,exFDsPtr EXFDS1, FDsPtr FDS1, FDsidxPtr FDS1idx,  double SymCheck_th, int enable_degen_check);
+            int * data_out, int do_lo, unsigned inlLimit, double **resids, double* H_best, int* Ih, exFDsPtr EXFDS1, FDsPtr FDS1, FDsidxPtr FDS1idx,
+            double SymCheck_th, int enable_degen_check, int seed);
 
 #ifdef __cplusplus
 extern "C"
@@ -110,4 +111,3 @@ void exFDsSym (const double *u, const double *F, double *p, double *w, int len);
 
 
 #endif // _EXP_RANSAC_RAN_F
-

--- a/src/pydegensac/degensac/exp_ranH.c
+++ b/src/pydegensac/degensac/exp_ranH.c
@@ -479,7 +479,8 @@ Score exp_ransacHcustomLAF (double *u, double *u_1, double *u_2,
                             HDsPtr HDS1,
                             HDsiPtr HDSi1,
                             HDsidxPtr HDSidx1,
-                            double SymCheck_th)
+                            double SymCheck_th,
+                            int seed)
 {
     int *pool, no_sam, new_sam, *samidx, bestsamidx[4];
     double *Z, *buffer;
@@ -489,7 +490,7 @@ Score exp_ransacHcustomLAF (double *u, double *u_1, double *u_2,
     int i, j, *inliers, *inliersS;
     char do_update = 0;
     Score maxS = {0,0,0,0}, maxSs = {0,0,0,0}, S = {0,0,0,0}, Scheck= {0,0,0,0};
-    unsigned seed;
+    unsigned rand_seed;
     int do_iterate;
     int iter_cnt = 0, no_rej = 0, iterID = 0;
     char new_max = 0;
@@ -505,7 +506,11 @@ Score exp_ransacHcustomLAF (double *u, double *u_1, double *u_2,
     }
     h = sol;
     //
-    srand(time(NULL)); //Mishkin - randomization
+    if (seed >= 0) {
+        srand((unsigned)seed);
+    } else {
+        srand(time(NULL)); //Mishkin - randomization
+    }
 
 #ifdef __HASHING__
     htInit(&HASH_TABLE);
@@ -534,7 +539,7 @@ Score exp_ransacHcustomLAF (double *u, double *u_1, double *u_2,
 
 
     no_sam = 0;
-    seed = rand();
+    rand_seed = rand();
 
     samidx = pool + len - 4;
 
@@ -545,9 +550,9 @@ Score exp_ransacHcustomLAF (double *u, double *u_1, double *u_2,
     while(no_sam < max_sam)
     {
         no_sam++;
-        srand(seed);
+        srand(rand_seed);
         multirsampleT(Z, 9, 2, pool, 4, len, M);
-        seed = rand();
+        rand_seed = rand();
 
         /* orientation */
 #ifndef __OC_OFF__

--- a/src/pydegensac/degensac/exp_ranH.h
+++ b/src/pydegensac/degensac/exp_ranH.h
@@ -30,10 +30,10 @@ Score exp_ransacHcustomLAF (double *u, double *u_1, double *u_2, int len, double
                             double *H, unsigned char * inl,
                             int iter_type, int * data_out,
                             int oriented_constraint, unsigned inlLimit, double **resids,
-                            HDsPtr HDS1, HDsiPtr HDSi1, HDsidxPtr HDSidx1, double SymCheck_th);
+                            HDsPtr HDS1, HDsiPtr HDSi1, HDsidxPtr HDSidx1, double SymCheck_th,
+                            int seed);
 /* Model-Change Error of homography (squared),
         deefined as mean square error of sample points when added the point as hard constraint */
 void hMCEs(double *Z, double *u, double *d, int *samidx, int len, double * errs, double thr);
 
 #endif
-


### PR DESCRIPTION
### Motivation
- Ensure prebuilt wheels are produced for up to Python 3.14 across all platforms to restore previously-supported targets in the CI matrix. 
- Provide deterministic/random-seed control for RANSAC routines to allow reproducible or seeded random behavior. 
- Bump the package version to reflect the next release. 

### Description
- Bumped package version in `setup.py` from `0.1.2` to `0.2`. 
- Added an optional `seed` parameter to the Python bindings (`findHomography_` and `findFundamentalMatrix_`) with default `-1`, and propagated the `seed` through calls into `exp_ransacFcustomLAF` and `exp_ransacHcustomLAF`. 
- Updated C sources and headers (`exp_ranF.c`, `exp_ranF.h`, `exp_ranH.c`, `exp_ranH.h`) to accept a `seed` argument and to initialize RNG via `srand((unsigned)seed)` when `seed >= 0`, otherwise falling back to `srand(time(NULL))`, and adjusted internal variable naming to avoid clobbering `seed`. 


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ecbd29de08324bdc024c2e2af5df4)