### PR TITLE
Add seeded reproducibility support and speed up F estimation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15...3.29)
+cmake_minimum_required(VERSION 3.9)
 project(pydegensac LANGUAGES C CXX)
 
 set(CMAKE_C_STANDARD 99)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,48 +1,62 @@
-cmake_minimum_required(VERSION 3.9)
-project(pydegensac)
+cmake_minimum_required(VERSION 3.15...3.29)
+project(pydegensac LANGUAGES C CXX)
 
-add_definitions(-fPIC)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
 
-FIND_PACKAGE(LAPACK REQUIRED)
-if (LAPACK_FOUND)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LAPACK_CXX_FLAGS}")
-endif (LAPACK_FOUND)
-
-SET(CMAKE_BUILD_TYPE "RELEASE")
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-IF(CMAKE_COMPILER_IS_GNUCXX)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-strict-aliasing")
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wno-write-strings")
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated")
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -ftree-vectorize -funroll-loops")
-ENDIF(CMAKE_COMPILER_IS_GNUCXX)
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
+endif()
+
+add_definitions(-fPIC)
+
+find_package(LAPACK REQUIRED)
 
 add_subdirectory(src/pydegensac/matutls)
 add_subdirectory(lib/pybind11)
 
-
-####### DEGENSAC
 include_directories(
-src/pydegensac
-src/pydegensac/degensac)
+  src/pydegensac
+  src/pydegensac/degensac
+)
+
 set(degensac_srcs
-        src/pydegensac/degensac/DegUtils.c
-        src/pydegensac/degensac/exp_ranF.c
-        src/pydegensac/degensac/exp_ranH.c
-        src/pydegensac/degensac/Ftools.c
-        src/pydegensac/degensac/hash.c
-        src/pydegensac/degensac/Htools.c
-        src/pydegensac/degensac/ranF.c
-        src/pydegensac/degensac/ranH2el.c
-        src/pydegensac/degensac/ranH.c
-        src/pydegensac/degensac/rtools.c
-        src/pydegensac/degensac/utools.c
-        src/pydegensac/degensac/lapwrap.c
+  src/pydegensac/degensac/DegUtils.c
+  src/pydegensac/degensac/exp_ranF.c
+  src/pydegensac/degensac/exp_ranH.c
+  src/pydegensac/degensac/Ftools.c
+  src/pydegensac/degensac/hash.c
+  src/pydegensac/degensac/Htools.c
+  src/pydegensac/degensac/ranF.c
+  src/pydegensac/degensac/ranH2el.c
+  src/pydegensac/degensac/ranH.c
+  src/pydegensac/degensac/rtools.c
+  src/pydegensac/degensac/utools.c
+  src/pydegensac/degensac/lapwrap.c
 )
 
 add_library(pydegensac_support ${degensac_srcs})
+
+# Core speed flags for BOTH C and C++
+target_compile_options(pydegensac_support PRIVATE
+  $<$<COMPILE_LANGUAGE:C>:
+    -O3 -fno-math-errno -ffp-contract=fast
+  >
+  $<$<COMPILE_LANGUAGE:CXX>:
+    -O3 -fno-math-errno -ffp-contract=fast
+  >
+)
+
+# Optional local-only (don't use for distributing wheels):
+# target_compile_options(pydegensac_support PRIVATE -march=native)
+
 pybind11_add_module(pydegensac "src/pydegensac/bindings.cpp")
+target_compile_options(pydegensac PRIVATE -O3 -fno-math-errno -ffp-contract=fast)
+
+target_link_libraries(pydegensac_support PRIVATE ${LAPACK_LIBRARIES} matutls)
 target_link_libraries(pydegensac PRIVATE ${LAPACK_LIBRARIES} matutls pydegensac_support)

--- a/docker/README.txt
+++ b/docker/README.txt
@@ -7,7 +7,7 @@
 ```bash
 sudo docker buildx build .
 sudo docker image ls
-sudo docker run --name pydegensac2 -v $(pwd):/mnt/pydegensac -it IMG_ID
+sudo docker run --name pydegensac -v $(pwd):/mnt/pydegensac -it IMG_ID
 alias cmake=/usr/local/bin/cmake
 /opt/python/cp36-cp36m/bin/python3 setup.py bdist_wheel
 auditwheel repair dist/pydegensac-0.1.1-cp36-cp36m-linux_x86_64.whl

--- a/src/pydegensac/__init__.py
+++ b/src/pydegensac/__init__.py
@@ -1,4 +1,6 @@
 from .pydegensac import *
-from .utils import (findHomography,
-                    findFundamentalMatrix,
-                    convert_cv2_kpts_to_xyA)
+from .utils import (
+    convert_cv2_kpts_to_xyA,
+    findFundamentalMatrix,
+    findHomography,
+)

--- a/src/pydegensac/degensac/Ftools.c
+++ b/src/pydegensac/degensac/Ftools.c
@@ -12,6 +12,156 @@
 #define SYMMETRIC_ERROR
 #define SYMMETRIC_ERROR_CHECK
 #define pit 1.0471975511965967
+
+static inline double trunc_quad_local(double epsilon, double thr)
+{
+    if (thr == 0) {
+        return 0;
+    }
+    if (epsilon >= thr * 9 / 4) {
+        return 0;
+    }
+    return 1 - (epsilon / (thr * 9 / 4));
+}
+
+static inline void score_accum_local(double e, double th, unsigned *I, double *J)
+{
+    if (e <= th) {
+        ++(*I);
+    }
+    *J += trunc_quad_local(e, th);
+}
+
+void F_sampson_count(const double *uu, int len, const double *FF, double th,
+                     unsigned *I, double *J)
+{
+    const double f1 = FF[0], f2 = FF[1], f3 = FF[2];
+    const double f4 = FF[3], f5 = FF[4], f6 = FF[5];
+    const double f7 = FF[6], f8 = FF[7], f9 = FF[8];
+    unsigned Ii = 0;
+    double Jj = 0;
+    const double *p = uu;
+    int idx;
+
+    for (idx = 0; idx < len; ++idx, p += 6) {
+        const double x1 = p[0], y1 = p[1];
+        const double x2 = p[3], y2 = p[4];
+        const double rxc = f1 * x2 + f4 * y2 + f7;
+        const double ryc = f2 * x2 + f5 * y2 + f8;
+        const double rwc = f3 * x2 + f6 * y2 + f9;
+        const double r = x1 * rxc + y1 * ryc + rwc;
+        const double rx = f1 * x1 + f2 * y1 + f3;
+        const double ry = f4 * x1 + f5 * y1 + f6;
+        const double denom = rxc * rxc + ryc * ryc + rx * rx + ry * ry;
+        const double e = r * r / denom;
+        score_accum_local(e, th, &Ii, &Jj);
+    }
+
+    *I = Ii;
+    *J = Jj;
+}
+
+void F_sampson_gather(const double *uu, int len, const double *FF, double th,
+                      double *err_out, int *inliers_out,
+                      unsigned *I, double *J)
+{
+    const double f1 = FF[0], f2 = FF[1], f3 = FF[2];
+    const double f4 = FF[3], f5 = FF[4], f6 = FF[5];
+    const double f7 = FF[6], f8 = FF[7], f9 = FF[8];
+    unsigned Ii = 0;
+    double Jj = 0;
+    const double *p = uu;
+    int idx;
+
+    for (idx = 0; idx < len; ++idx, p += 6) {
+        const double x1 = p[0], y1 = p[1];
+        const double x2 = p[3], y2 = p[4];
+        const double rxc = f1 * x2 + f4 * y2 + f7;
+        const double ryc = f2 * x2 + f5 * y2 + f8;
+        const double rwc = f3 * x2 + f6 * y2 + f9;
+        const double r = x1 * rxc + y1 * ryc + rwc;
+        const double rx = f1 * x1 + f2 * y1 + f3;
+        const double ry = f4 * x1 + f5 * y1 + f6;
+        const double denom = rxc * rxc + ryc * ryc + rx * rx + ry * ry;
+        const double e = r * r / denom;
+
+        err_out[idx] = e;
+        if (e <= th) {
+            inliers_out[Ii] = idx;
+        }
+        score_accum_local(e, th, &Ii, &Jj);
+    }
+
+    *I = Ii;
+    *J = Jj;
+}
+
+void F_symm_count(const double *uu, int len, const double *FF, double th,
+                  unsigned *I, double *J)
+{
+    const double f1 = FF[0], f2 = FF[1], f3 = FF[2];
+    const double f4 = FF[3], f5 = FF[4], f6 = FF[5];
+    const double f7 = FF[6], f8 = FF[7], f9 = FF[8];
+    unsigned Ii = 0;
+    double Jj = 0;
+    const double *p = uu;
+    int idx;
+
+    for (idx = 0; idx < len; ++idx, p += 6) {
+        const double x1 = p[0], y1 = p[1];
+        const double x2 = p[3], y2 = p[4];
+        const double rxc = f1 * x2 + f4 * y2 + f7;
+        const double ryc = f2 * x2 + f5 * y2 + f8;
+        const double rwc = f3 * x2 + f6 * y2 + f9;
+        const double r = x1 * rxc + y1 * ryc + rwc;
+        const double rx = f1 * x1 + f2 * y1 + f3;
+        const double ry = f4 * x1 + f5 * y1 + f6;
+        const double denom_a = rxc * rxc + ryc * ryc;
+        const double denom_b = rx * rx + ry * ry;
+        const double e = r * r * (denom_a + denom_b) / (denom_a * denom_b);
+        score_accum_local(e, th, &Ii, &Jj);
+    }
+
+    *I = Ii;
+    *J = Jj;
+}
+
+void F_symm_gather(const double *uu, int len, const double *FF, double th,
+                   double *err_out, int *inliers_out,
+                   unsigned *I, double *J)
+{
+    const double f1 = FF[0], f2 = FF[1], f3 = FF[2];
+    const double f4 = FF[3], f5 = FF[4], f6 = FF[5];
+    const double f7 = FF[6], f8 = FF[7], f9 = FF[8];
+    unsigned Ii = 0;
+    double Jj = 0;
+    const double *p = uu;
+    int idx;
+
+    for (idx = 0; idx < len; ++idx, p += 6) {
+        const double x1 = p[0], y1 = p[1];
+        const double x2 = p[3], y2 = p[4];
+        const double rxc = f1 * x2 + f4 * y2 + f7;
+        const double ryc = f2 * x2 + f5 * y2 + f8;
+        const double rwc = f3 * x2 + f6 * y2 + f9;
+        const double r = x1 * rxc + y1 * ryc + rwc;
+        const double rx = f1 * x1 + f2 * y1 + f3;
+        const double ry = f4 * x1 + f5 * y1 + f6;
+        const double denom_a = rxc * rxc + ryc * ryc;
+        const double denom_b = rx * rx + ry * ry;
+        const double e = r * r * (denom_a + denom_b) / (denom_a * denom_b);
+
+        err_out[idx] = e;
+        if (e <= th) {
+            inliers_out[Ii] = idx;
+        }
+        score_accum_local(e, th, &Ii, &Jj);
+    }
+
+    *I = Ii;
+    *J = Jj;
+}
+
 void lin_fm(const double *u, double *p, const int* inl, const int len)
 {
     /* linearizes corresp. with respect to entries of fundamental matrix,
@@ -363,7 +513,6 @@ void u2f(const double *u, const int *inl, int len,
     {
         normu (u, inl, len, A1, A2);
         lin_fmN(u, Z, inl, len, A1, A2);
-
         cov_mat(V, Z, len, 9);
         lap_eig(V,D,9);
         trnm(V,9); /* lapack stores column-wise */
@@ -665,4 +814,3 @@ int nullspace_qr7x9(const double *A, double *N)
     }
     return 0;
 }
-

--- a/src/pydegensac/degensac/Ftools.h
+++ b/src/pydegensac/degensac/Ftools.h
@@ -32,6 +32,29 @@
 #define rr_d (*(po + 3))
 
 #include "Fcustomdef.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void F_sampson_count(const double *u, int len, const double *F, double th,
+                     unsigned *I, double *J);
+
+void F_sampson_gather(const double *u, int len, const double *F, double th,
+                      double *err_out, int *inliers_out,
+                      unsigned *I, double *J);
+
+void F_symm_count(const double *u, int len, const double *F, double th,
+                  unsigned *I, double *J);
+
+void F_symm_gather(const double *u, int len, const double *F, double th,
+                   double *err_out, int *inliers_out,
+                   unsigned *I, double *J);
+
+#ifdef __cplusplus
+}
+#endif
+
 void lin_fm(const double *u, double *p, const int* inl, const int len);
 
 void slcm(double *A, double *B, double *p);

--- a/src/pydegensac/degensac/exp_ranF.c
+++ b/src/pydegensac/degensac/exp_ranF.c
@@ -44,16 +44,6 @@ static HashTable HASH_TABLE_F;
 #define max(a,b) ((a) > (b) ? (a) : (b))
 #endif
 
-int no_mto(double *A)
-{
-    double x,y;
-    int i,j;
-    int pts_ok = 1;
-    for (i=0;i<7;i++)
-        for (j=i+1;j<7;j++)
-            pts_ok = 0;//()
-}
-
 
 Score exp_iterF(double *u, int len, int *inliers, int * inl2, double th, double ths, int iters,
                 double *F, double **errs, double *buffer, int * samidx, int iterID, unsigned inlLimit, double *resids) {
@@ -809,439 +799,6 @@ Score exp_inFranicustom (double *u, int len, int *inliers, int ninl,
 /*********************   RANSAC   ************************/
 
 
-int exp_ransacFcustom(double *u, int len, double th, double conf, int max_sam,
-                      double *F, unsigned char * inl,
-                      int * data_out, int do_lo, unsigned inlLimit, double **resids, double* H_best, int* Ih,exFDsPtr EXFDS1,FDsPtr FDS1, int doSymCheck) {
-    unsigned seed;
-
-    int *pool, no_sam, new_sam;
-    double *Z, *buffer, u7[6*7], H[3*3], FBest[3*3];
-    int * bufferP;
-    double *f1, *f2;
-
-    double poly[4], roots[3], f[9], *err, *d, *d_check;
-    double *errs[5];
-    int nsol, i, j, *inliers, new_max, do_iterate;
-    unsigned I;
-    Score maxS = {0, 0, 0, 0}, maxSs ={0, 0, 0, 0}, S = {0, 0, 0, 0}, Scheck={0, 0, 0, 0};
-    int *samidx, samidxBest[7];
-    double * errorsBest; /*To store best non-deg inls for ALO LO*/ //TODO replace with errs[3], there are the same data! BUT! do we want BEST data or BEST NON-DEGENERATED data? :(
-    /* to eliminate */
-    int degen_cnt = 0, iter_cnt = 0, LmaxI, iterID = 0;
-    unsigned non_degen_samples_count = 0; //only those with so-far-the-best model
-    double jj;
-    double * HDs = (double *) malloc(len*sizeof(double));
-    // int bad_model = 0; //Mishkin
-    int Ihmax = 0;//Mishkin
-    double Hbest[9]; //Mishkin
-    int a; //Mishkin, counter;
-    double SymCheck_th =  CHECK_COEF*th;
-
-    srand(time(NULL)); //Mishkin - randomization
-
-#ifdef USE_QR
-    double A[7*9], sol[2*9];
-#else
-    double A[9*9], sol[9*9];
-    int nullspace_buff[2*9];
-    int nullsize;
-    for (i=7*9; i<9*9; i++) {
-        A[i] = 0.0;
-    }
-#endif
-
-#ifdef __HASHING__
-    htInit(&HASH_TABLE_F);
-#endif // __HASHING__
-
-    ////printf("__PROFILE: BEFORE ransac: %d\n", getticks()/1000);
-
-    /* allocations */
-
-    pool = (int *)malloc(len * sizeof(int));
-    for (i = 0; i < len; i ++) {
-        pool[i] = i;
-    }
-    samidx = pool + len - 7;
-
-    Z = (double *) malloc(len * 9 * sizeof(double));
-    lin_fm(u, Z, pool, len);
-
-    buffer = (double *) malloc(len * 18 * sizeof(double)); /*It would be enough 9 for u2f, but dHDs needs 18*/
-    bufferP = (int *) malloc(len * sizeof(int));
-
-    errorsBest = (double *) malloc(len * sizeof(double));
-    err = (double *) malloc(len * 4 * sizeof(double));
-    d_check = (double *) malloc(len * sizeof(double));
-    for (i=0; i<4; i++)
-        errs[i] = err + i * len;
-    errs[4] = errs[3];
-
-    inliers = (int *) malloc(sizeof(int) * len);
-
-    *resids = (double *) malloc (iter_cnt * RESIDS_M * len * sizeof(double));
-
-    maxS.I  = 8;
-    maxSs.I = 8;
-    // max_sam = MAX_SAMPLES;
-    no_sam = 0;
-
-    f1 = sol;
-    f2 = sol+9;
-
-    seed = rand();
-
-    /*  srand(RAND_SEED++); */
-    while(no_sam < max_sam) {
-        no_sam ++;
-
-        srand(seed);
-
-        rsampleT(Z, 9, pool, 7, len, A);
-        loadSample(u, samidx, 7, 6, u7);
-
-        seed = rand();
-        ////printf("Seed: %d\n",seed);
-
-
-#if USE_QR
-        /* QR */
-        nullspace_qr7x9(A, sol);
-#else
-        /* use LU */
-        for (i = 7*9; i < 9*9; ++i) {
-            A[i] = 0.0;
-        }
-
-        nullsize = nullspace(A, f1, 9, nullspace_buff);
-        if (nullsize != 2) {
-            continue;
-        }
-#endif
-        slcm (f1, f2, poly);
-        nsol = rroots3(poly, roots);
-
-        new_max = 0; do_iterate = 0;
-        LmaxI = 0;
-        for (i = 0; i < nsol; i++) {
-            for (j = 0; j < 9; j++) {
-                f[j] = f1[j] * roots[i] + f2[j] * (1 -roots[i]);
-            }
-
-            /* orient. constr. */
-#ifndef __OC_OFF__
-            if (!all_ori_valid(f, u, samidx, 7))  continue;
-#endif
-
-            d = errs[i];
-            FDS1(u, f, d, len);
-            S = inlidxs(d, len, th, inliers);
-
-            if (S.I > LmaxI) LmaxI = S.I;
-
-            if(scoreLess(maxS, S)) {
-                ///
-                if (doSymCheck) { //Mishkin. Check by symmetrical distance
-                    FDsSym(u, f, d_check, len);
-                    S.Is = 0;
-                    for (j = 0; j < len; j++)
-                        if (d_check[j] <= SymCheck_th) S.Is++;
-
-                    if (S.Is < maxS.Is)
-                        continue;
-                }
-                errs[i] = errs[3];
-                errs[3] = d;
-                maxS = S;
-                ////printf("I risen in main loop to %u.\n", maxS.I);
-                memcpy(F,f,9*sizeof(double));
-                new_max = 1;
-            }
-
-
-
-
-
-            if(scoreLess(maxSs, S)) {
-                maxSs = S;
-                ////printf("__PROFILE: BEFORE checksample: %d\n", getticks()/1000);
-                if (checksample(f, u7, 3*th, H)) {
-                    ////printf("__PROFILE: AFTER  checksample: %d\n", getticks()/1000);
-                    dHDs(H, u, len, HDs, bufferP, buffer);
-                    I = 0;
-                    for (j = 0; j < len; ++j) {
-                        if (HDs[j] < th*3) {
-                            ++I;
-                        }
-                    }
-                    if (I < 8) {
-                        break;
-                    }
-                    ////printf("__PROFILE: BEFORE innerH: %d\n", getticks()/1000);
-                    ////printf("I before innrH %u.\n", I);
-
-                    I = innerH(H, u, len, 16*th, 10, inl, bufferP, buffer); /*originally was 30 reps, lowered because of bad performance*/
-
-                    if (I > Ihmax) {Ihmax = I; for (a=0;a<9;a++) Hbest[a] = H[a];};//Mishkin
-
-                    ////printf("I after innrH %u.\n", I);
-
-                    ////printf("__PROFILE: AFTER  innerH: %d\n", getticks()/1000);
-                    if (I > 6) {
-                        /*[aF, v] = rFtH(u, ahi, th, aH);
-                                                no_i = sum(v);
-                                                f//printf(1,'P+P %d %d\n',sum(ahi), no_i);*/
-                        ////printf("__PROFILE: BEFORE rFtH: %d\n", getticks()/1000);
-                        I = rFtH(u, inl, th, H, len, f, bufferP, buffer);
-                        ////printf("I after rFtH %u.\n", I);
-
-                        ////printf("__PROFILE: AFTER  rFtH: %d\n", getticks()/1000);
-                        if(I > maxS.I) { //TODO hybrid scoring down to rFtH?
-                            FDS1(u, f, errs[3], len);
-                            maxS.I = I; /*maxS.J is set later*/
-                            ////printf("I risen in degen to %u.\n", maxS.I);
-                            memcpy(F,f,3*3*sizeof(double));
-                            new_max = 1;
-                            d = errs[3]; /*For IJ calculation*/
-                        } else {
-                            FDS1(u, f, errs[i], len);
-                            d = errs[i]; /*For IJ calculation*/
-                        }
-                        I = 0;
-                        jj = 0;
-                        for (j = 0; j < len; j++) {
-                            if (d[j] <= th) {
-                                I++;
-                            }
-                            jj += truncQuad(d[j],th);
-                        }
-                        if (new_max) {
-                            maxS.J = jj;
-                        }
-                        ++degen_cnt;
-                    }
-                } else {
-                    ////printf("__PROFILE: AFTER  checksample: %d\n", getticks()/1000);
-                    do_iterate = (do_lo>0 && (no_sam > ITER_SAM));
-                    errs[4] = d;
-                    non_degen_samples_count++;
-                    memcpy(samidxBest, samidx, 7 * sizeof(int));
-                    memcpy(errorsBest, d, len * sizeof(double));
-                    memcpy(FBest, f, 3*3*sizeof(double));
-                }
-            }
-        }
-
-        data_out[LmaxI+2] ++;
-
-        if (do_lo>0 && (no_sam == ITER_SAM) && non_degen_samples_count) {
-            do_iterate = 1;
-        }
-
-        if (do_iterate) {
-            iter_cnt ++;
-            *resids = (double *) realloc(*resids, iter_cnt * RESIDS_M * len * sizeof(double));
-            memcpy(*resids + RESIDS_M*(iter_cnt - 1)*len, errs[4], len*sizeof(double));
-
-#ifdef __LSQ_BEFORE_LO__
-            d = errs[0];
-            S = inlidxs(errs[4], len, TC*th*MWM, inliers);
-            u2f(u, inliers, S.I, f, buffer);
-            FDS1(u, f, d, len);
-            S = inlidxs(d, len, th, inliers);
-            memcpy(*resids + RESIDS_M*(iter_cnt - 1)*len + len, d, len*sizeof(double));
-#else
-            S = inlidxs(errs[4], len, th, inliers);
-#endif /* __LSQ_BEFORE_LO__ */
-            /*******/
-            S = exp_inFranicustom(u, len, inliers, S.I, th, errs, buffer, f, samidx, &iterID, inlLimit, *resids + 2*len + (iter_cnt-1)*RESIDS_M*len,EXFDS1,FDS1);
-            /*******/
-            // minimalistic LO' (just one iterations)
-            /*			S = exp_iterF(u, len, inliers, bufferP, th, 16*TC*th, 10, f, errs, buffer, samidx, ++iterID, inlLimit, *resids + 2*len + (iter_cnt-1)*RESIDS_M*len);*/
-            /*******/
-
-            if(scoreLess(maxS, S)) {
-                char do_update = 1;
-                if (doSymCheck) { //Mishkin. Check by symmetrical distance
-                    FDsSym(u, f, d_check, len);
-                    S.Is = 0;
-                    double SymCheck_th =  CHECK_COEF*th;
-                    for (j = 0; j < len; j++)
-                        if (d_check[j] <= SymCheck_th) S.Is++;
-
-                    if (S.Is < maxS.Is)
-                        do_update = 0;
-                }
-                if (do_update) {
-                    ////printf("LO %d\n", I);
-                    d = errs[0];
-                    errs[0] = errs[3];
-                    errs[3] = d;
-                    maxS = S;
-                    ////printf("I risen in LO to %u.\n", maxI);
-                    memcpy(F,f,9*sizeof(double)); /*!!!*/
-                    new_max = 1;
-                }
-            }
-        }
-
-        if (new_max) {
-            new_sam = nsamples(maxS.I+1, len, 7, conf);
-            if (new_sam < max_sam) {
-                max_sam = new_sam;
-            }
-        }
-    }
-
-    /*If there were no LOs, do at least one NOW!*/
-    if (do_lo && (!iter_cnt && !degen_cnt) && non_degen_samples_count) { //TODO maybe not a good idea to supress LO after degen...? full vs. full+
-        ////printf("Running ALO LO\n");
-        loadSample(u, samidxBest, 7, 6, u7);
-        if (checksample(FBest, u7, 3*th, H)) { //TODO is this necessary? NO, if running full+ version (degen_cnt > 0 if found deg. sample with big consensus)
-            ////printf("__PROFILE: AFTER  checksample: %d\n", getticks()/1000);
-            dHDs(H, u, len, HDs, bufferP, buffer);
-            I = 0;
-            for (j = 0; j < len; ++j) {
-                if (HDs[j] < th*3) {
-                    ++I;
-                }
-            }
-            if (I >= 8) {
-                ////printf("__PROFILE: BEFORE innerH: %d\n", getticks()/1000);
-                I = innerH(H, u, len, 16*th, 10, inl, bufferP, buffer); /*originally was 30 reps, lowered because of bad performance*/
-                ////printf("__PROFILE: AFTER  innerH: %d\n", getticks()/1000);
-            }
-            if (I > Ihmax) {Ihmax = I; for (a=0;a<9;a++) Hbest[a] = H[a];};//Mishkin
-
-            if (I > 6) {
-                /*[aF, v] = rFtH(u, ahi, th, aH);
-                                no_i = sum(v);
-                                f//printf(1,'P+P %d %d\n',sum(ahi), no_i);*/
-                ////printf("__PROFILE: BEFORE rFtH: %d\n", getticks()/1000);
-                I = rFtH(u, inl, th, H, len, f, bufferP, buffer);
-                ////printf("__PROFILE: AFTER  rFtH: %d\n", getticks()/1000);
-                if(I > maxS.I) { //TODO hybrid scoring down to rFtH?
-                    FDS1(u, f, errs[3], len);
-                    maxS.I = I; /*maxS.J is set later*/
-                    ////printf("I risen in degen to %u.\n", maxS.I);
-                    memcpy(F,f,3*3*sizeof(double));
-                    new_max = 1;
-                    d = errs[3]; /*For IJ calculation*/
-                } else {
-                    FDS1(u, f, errs[i], len);
-                    d = errs[i]; /*For IJ calculation*/
-                }
-                I = 0;
-                jj = 0;
-                for (j = 0; j < len; j++) {
-                    if (d[j] <= th) {
-                        I++;
-                    }
-                    jj += truncQuad(d[j],th);
-                }
-                if (new_max) {
-                    maxS.J = jj;
-                }
-                ++degen_cnt;
-            }
-        } else {
-            iter_cnt ++;
-
-            *resids = (double *) realloc(*resids, iter_cnt * RESIDS_M * len * sizeof(double));
-            memcpy(*resids + RESIDS_M*(iter_cnt - 1)*len, errs[4], len*sizeof(double));
-#ifdef __LSQ_BEFORE_LO__
-            d = errs[0];
-            S = inlidxs(errorsBest, len, TC*th*MWM, inliers);
-            u2f(u, inliers, S.I, f, buffer);
-            FDS1(u, f, d, len);
-            S = inlidxs(d, len, th, inliers);
-            memcpy(*resids + RESIDS_M*(iter_cnt - 1)*len + len, d, len*sizeof(double));
-#else
-            S = inlidxs(errorsBest, len, th, inliers);
-#endif /* __LSQ_BEFORE_LO__ */
-            /*******/
-            S = exp_inFranicustom (u, len, inliers, S.I, th, errs, buffer, f, samidxBest, &iterID, inlLimit, *resids + 2*len + (iter_cnt-1)*RESIDS_M*len,EXFDS1,FDS1);
-            /*******/
-            // minimalistic LO' (just one iterations)
-            /*			S = exp_iterF(u, len, inliers, bufferP, th, 16*TC*th, 10, f, errs, buffer, samidxBest, ++iterID, inlLimit, *resids + 2*len + (iter_cnt-1)*RESIDS_M*len);*/
-            /*******/
-
-            if(scoreLess(maxS, S)) {
-                char do_update = 1;
-                if (doSymCheck) { //Mishkin. Check by symmetrical distance
-                    FDsSym(u, f, d_check, len);
-                    S.Is = 0;
-
-                    for (j = 0; j < len; j++)
-                        if (d_check[j] <= SymCheck_th) S.Is++;
-
-                    if (S.Is < maxS.Is)
-                        do_update = 0;
-                }
-                if (do_update) {
-                    ////printf("LO %d\n", I);
-                    d = errs[0];
-                    errs[0] = errs[3];
-                    errs[3] = d;
-                    maxS = S;
-                    ////printf("I risen in LO to %u.\n", maxI);
-                    memcpy(F,f,9*sizeof(double)); /*!!!*/
-                    new_max = 1;
-                }
-            }
-        }
-    }
-
-    d = errs[3];
-
-#ifdef __FINAL_LSQ__
-    I = inlidxs(d, len, th, inliers); //LSQ in the end
-    u2f(u, inliers, I, F, buffer);
-    FDS1(u, F, d, len);
-#endif
-
-    for (j = 0; j < len; j++) {
-        if (d[j] <= th) {
-            inl[j] = 1;
-        } else {
-            inl[j] = 0;
-        }
-
-    }
-    if (doSymCheck) { //Mishkin. Check by symmetrical distance
-
-        S =  inlidxs(d, len, th, inliers);
-        FDsSym(u, f, d_check, len);
-
-        for (j = 0; j < len; j++)
-            if (d_check[j] > SymCheck_th)
-                inl[j] = 0;
-    }
-
-    /* deallocations */
-
-#ifdef __HASHING__
-    htClear(&HASH_TABLE_F);
-#endif // __HASHING__
-    free(d_check);
-    free(pool);
-    free(Z);
-    free(err);
-    free(errorsBest);
-    free(inliers);
-    free(buffer);
-    free(bufferP);
-    free(HDs);
-    *data_out = no_sam;
-    data_out[1] = iter_cnt;
-
-    ////printf("__PROFILE: AFTER ransac: %d\n", getticks()/1000);
-    *Ih = Ihmax;
-    for (a=0;a<0;a++)
-        H_best[a] = Hbest[a];
-    return maxS.I;
-};
-
 int exp_ransacFcustomLAF(double *u, double *u_1, double *u_2, int len, double th, double laf_coef,
                          double conf, int max_sam,
                          double *F, unsigned char * inl,
@@ -1275,6 +832,8 @@ int exp_ransacFcustomLAF(double *u, double *u_1, double *u_2, int len, double th
     int p1_inliers = 0;
     double *err_laf;
     int a;
+    const int use_fast_sampson = FDS1 == &FDs;
+    const int use_fast_symm = FDS1 == &FDsSym;
 
     if (seed >= 0) {
         srand((unsigned)seed);
@@ -1378,11 +937,44 @@ int exp_ransacFcustomLAF(double *u, double *u_1, double *u_2, int len, double th
             if (!all_ori_valid(f, u, samidx, 7))  continue;
 #endif
 
-            d = errs[i];
-            FDS1(u, f, d, len);
-            S = inlidxs(d, len, th, inliers);
+            {
+                int can_improve_maxSs;
+                unsigned fast_I = 0;
+                double fast_J = 0;
 
-            if (S.I > LmaxI) LmaxI = S.I;
+                if (use_fast_sampson) {
+                    F_sampson_count(u, len, f, th, &fast_I, &fast_J);
+                    S.I = fast_I;
+                    S.J = fast_J;
+                } else if (use_fast_symm) {
+                    F_symm_count(u, len, f, th, &fast_I, &fast_J);
+                    S.I = fast_I;
+                    S.J = fast_J;
+                } else {
+                    d = errs[i];
+                    FDS1(u, f, d, len);
+                    S = inlidxs(d, len, th, inliers);
+                }
+
+                can_improve_maxSs = scoreLess(maxSs, S);
+
+                if (S.I > LmaxI) LmaxI = S.I;
+
+                if (use_fast_sampson || use_fast_symm) {
+                    if (!(scoreLess(maxS, S) || can_improve_maxSs)) {
+                        continue;
+                    }
+
+                    d = errs[i];
+                    if (use_fast_sampson) {
+                        F_sampson_gather(u, len, f, th, d, inliers, &fast_I, &fast_J);
+                    } else {
+                        F_symm_gather(u, len, f, th, d, inliers, &fast_I, &fast_J);
+                    }
+                    S.I = fast_I;
+                    S.J = fast_J;
+                }
+            }
 
             if(scoreLess(maxS, S)) {
                 ///

--- a/src/pydegensac/utils.py
+++ b/src/pydegensac/utils.py
@@ -1,4 +1,4 @@
-import pydegensac
+from . import pydegensac
 
 import numpy as np
 import math
@@ -78,7 +78,8 @@ def findHomography(pts1_,
                    max_iters = 50000,
                    laf_consistensy_coef = -1.0,
                    error_type = "sampson",
-                   symmetric_error_check = True):
+                   symmetric_error_check = True,
+                   seed = -1):
     pts1 = convert_and_check(pts1_)
     pts2 = convert_and_check(pts2_)
     n, dim = pts1.shape
@@ -100,7 +101,8 @@ def findHomography(pts1_,
                              max_iters,
                              error_type_int,
                              symmetric_error_check,
-                             laf_consistensy_coef);
+                             laf_consistensy_coef,
+                             seed);
     if np.abs(H).sum() == 0:
         # If we haven`t found any good model, output zeros
         mask = [False]*len(mask)
@@ -116,7 +118,8 @@ def findFundamentalMatrix(pts1_,
                    laf_consistensy_coef = -1.0,
                    error_type = "sampson",
                    symmetric_error_check = True,
-                   enable_degeneracy_check = True):
+                   enable_degeneracy_check = True,
+                   seed = -1):
     pts1 = convert_and_check(pts1_)
     pts2 = convert_and_check(pts2_)
     n, dim = pts1.shape
@@ -139,9 +142,9 @@ def findFundamentalMatrix(pts1_,
                          error_type_int,
                          symmetric_error_check,
                          laf_consistensy_coef,
-                         enable_degeneracy_check);
+                         enable_degeneracy_check,
+                         seed);
     if np.abs(F).sum() == 0:
         # If we haven`t found any good model, output zeros
         mask = [False]*n
     return F, mask
-

--- a/tests/test_seed_reproducibility.py
+++ b/tests/test_seed_reproducibility.py
@@ -1,0 +1,134 @@
+import numpy as np
+
+import pydegensac
+
+
+def _make_homography_data():
+    rng = np.random.default_rng(0)
+    pts1_in = rng.uniform(-50.0, 50.0, size=(48, 2))
+    H_true = np.array(
+        [
+            [1.02, 0.04, 8.0],
+            [-0.03, 0.97, -5.0],
+            [0.0006, -0.0004, 1.0],
+        ],
+        dtype=np.float64,
+    )
+
+    homog = np.c_[pts1_in, np.ones(len(pts1_in))]
+    proj = homog @ H_true.T
+    pts2_in = proj[:, :2] / proj[:, 2:]
+
+    pts1_out = rng.uniform(-50.0, 50.0, size=(24, 2))
+    pts2_out = rng.uniform(-50.0, 50.0, size=(24, 2))
+
+    pts1 = np.vstack([pts1_in, pts1_out])
+    pts2 = np.vstack([pts2_in, pts2_out])
+    return pts1, pts2
+
+
+def _make_fundamental_data():
+    rng = np.random.default_rng(1)
+    pts3d = rng.uniform([-1.0, -1.0, 4.0], [1.0, 1.0, 8.0], size=(64, 3))
+
+    p1 = np.array(
+        [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    p2 = np.array(
+        [
+            [0.999, 0.0, 0.045, 0.35],
+            [0.002, 1.0, 0.0, -0.1],
+            [-0.045, 0.0, 0.999, 0.2],
+        ],
+        dtype=np.float64,
+    )
+
+    homog = np.c_[pts3d, np.ones(len(pts3d))]
+    x1 = homog @ p1.T
+    x2 = homog @ p2.T
+    pts1_in = x1[:, :2] / x1[:, 2:]
+    pts2_in = x2[:, :2] / x2[:, 2:]
+
+    pts1_out = rng.uniform(-0.5, 0.5, size=(24, 2))
+    pts2_out = rng.uniform(-0.5, 0.5, size=(24, 2))
+
+    pts1 = np.vstack([pts1_in, pts1_out])
+    pts2 = np.vstack([pts2_in, pts2_out])
+    return pts1, pts2
+
+
+def test_seed_reproducibility_homography():
+    pts1, pts2 = _make_homography_data()
+
+    h1, mask1 = pydegensac.findHomography(
+        pts1, pts2, px_th=0.25, conf=0.999, max_iters=5000, seed=1234
+    )
+    h2, mask2 = pydegensac.findHomography(
+        pts1, pts2, px_th=0.25, conf=0.999, max_iters=5000, seed=1234
+    )
+
+    assert np.array_equal(np.asarray(mask1), np.asarray(mask2))
+    assert np.allclose(h1, h2, rtol=0.0, atol=1e-12)
+
+
+def test_seed_reproducibility_fundamental():
+    pts1, pts2 = _make_fundamental_data()
+
+    f1, mask1 = pydegensac.findFundamentalMatrix(
+        pts1,
+        pts2,
+        px_th=1e-4,
+        conf=0.999,
+        max_iters=20000,
+        enable_degeneracy_check=True,
+        seed=5678,
+    )
+    f2, mask2 = pydegensac.findFundamentalMatrix(
+        pts1,
+        pts2,
+        px_th=1e-4,
+        conf=0.999,
+        max_iters=20000,
+        enable_degeneracy_check=True,
+        seed=5678,
+    )
+
+    assert np.array_equal(np.asarray(mask1), np.asarray(mask2))
+    assert np.allclose(f1, f2, rtol=0.0, atol=1e-9)
+
+
+def test_seeded_homography_returns_valid_model():
+    pts1, pts2 = _make_homography_data()
+
+    h, mask = pydegensac.findHomography(
+        pts1, pts2, px_th=0.25, conf=0.999, max_iters=50, seed=111
+    )
+
+    assert h.shape == (3, 3)
+    assert len(mask) == len(pts1)
+    assert np.isfinite(h).all()
+    assert int(np.asarray(mask, dtype=bool).sum()) >= 48
+
+
+def test_seeded_fundamental_returns_valid_model():
+    pts1, pts2 = _make_fundamental_data()
+
+    f, mask = pydegensac.findFundamentalMatrix(
+        pts1,
+        pts2,
+        px_th=1e-4,
+        conf=0.999,
+        max_iters=200,
+        enable_degeneracy_check=True,
+        seed=111,
+    )
+
+    assert f.shape == (3, 3)
+    assert len(mask) == len(pts1)
+    assert np.isfinite(f).all()
+    assert int(np.asarray(mask, dtype=bool).sum()) >= 64

--- a/tools/collect_fixed_seed_stats.py
+++ b/tools/collect_fixed_seed_stats.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+import argparse
+import csv
+import json
+import statistics
+from pathlib import Path
+
+from run_fixed_seed import run_estimation
+
+
+def write_summary(rows, output_path):
+    h_times = [row["h_time"] for row in rows]
+    f_times = [row["f_time"] for row in rows]
+    totals = [row["total_time"] for row in rows]
+    h_inliers = [row["h_inliers"] for row in rows]
+    f_inliers = [row["f_inliers"] for row in rows]
+
+    with output_path.open("w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["metric", "value"])
+        writer.writerow(["runs", len(rows)])
+        writer.writerow(["h_time_mean", statistics.mean(h_times)])
+        writer.writerow(["h_time_stdev", statistics.pstdev(h_times)])
+        writer.writerow(["f_time_mean", statistics.mean(f_times)])
+        writer.writerow(["f_time_stdev", statistics.pstdev(f_times)])
+        writer.writerow(["total_time_mean", statistics.mean(totals)])
+        writer.writerow(["total_time_stdev", statistics.pstdev(totals)])
+        writer.writerow(["h_inliers_mean", statistics.mean(h_inliers)])
+        writer.writerow(["f_inliers_mean", statistics.mean(f_inliers)])
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--seed-start", type=int, default=1234)
+    parser.add_argument("--count", type=int, default=10)
+    parser.add_argument("--stats-output", type=Path, required=True)
+    parser.add_argument("--summary-output", type=Path, required=True)
+    parser.add_argument("--json-dir", type=Path, default=None)
+    args = parser.parse_args()
+
+    args.stats_output.parent.mkdir(parents=True, exist_ok=True)
+    args.summary_output.parent.mkdir(parents=True, exist_ok=True)
+    if args.json_dir is not None:
+        args.json_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    with args.stats_output.open("w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            [
+                "run",
+                "seed",
+                "h_time",
+                "f_time",
+                "total_time",
+                "h_inliers",
+                "f_inliers",
+                "h_signature",
+                "f_signature",
+            ]
+        )
+
+        for offset in range(args.count):
+            seed = args.seed_start + offset
+            result = run_estimation(seed)
+            row = {
+                "run": offset + 1,
+                "seed": seed,
+                "h_time": result["homography"]["runtime_sec"],
+                "f_time": result["fundamental"]["runtime_sec"],
+                "total_time": (
+                    result["homography"]["runtime_sec"]
+                    + result["fundamental"]["runtime_sec"]
+                ),
+                "h_inliers": result["homography"]["inliers"],
+                "f_inliers": result["fundamental"]["inliers"],
+                "h_signature": result["homography"]["signature"],
+                "f_signature": result["fundamental"]["signature"],
+            }
+            rows.append(row)
+            writer.writerow(
+                [
+                    row["run"],
+                    row["seed"],
+                    row["h_time"],
+                    row["f_time"],
+                    row["total_time"],
+                    row["h_inliers"],
+                    row["f_inliers"],
+                    row["h_signature"],
+                    row["f_signature"],
+                ]
+            )
+
+            if args.json_dir is not None:
+                json_path = args.json_dir / f"seed_{seed}.json"
+                json_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+
+    write_summary(rows, args.summary_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/run_fixed_seed.py
+++ b/tools/run_fixed_seed.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+import argparse
+import json
+from pathlib import Path
+from time import perf_counter
+
+import cv2
+import numpy as np
+
+import pydegensac
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMG_DIR = ROOT / "examples" / "img" / "v_dogman"
+
+H_TH = 4.0
+H_CONF = 0.99
+H_ITERS = 2000
+
+F_TH = 0.5
+F_CONF = 0.999
+F_ITERS = 50000
+
+
+def load_tentatives():
+    img1 = cv2.cvtColor(cv2.imread(str(IMG_DIR / "1.ppm")), cv2.COLOR_BGR2RGB)
+    img2 = cv2.cvtColor(cv2.imread(str(IMG_DIR / "6.ppm")), cv2.COLOR_BGR2RGB)
+
+    det = cv2.AKAZE_create(descriptor_type=3, threshold=0.00001)
+    kps1, descs1 = det.detectAndCompute(img1, None)
+    kps2, descs2 = det.detectAndCompute(img2, None)
+
+    bf = cv2.BFMatcher()
+    matches = bf.knnMatch(descs1, descs2, k=2)
+
+    tentatives = []
+    for first, second in matches:
+        if first.distance < 0.9 * second.distance:
+            tentatives.append(first)
+
+    src_pts = np.float64([kps1[m.queryIdx].pt for m in tentatives]).reshape(-1, 2)
+    dst_pts = np.float64([kps2[m.trainIdx].pt for m in tentatives]).reshape(-1, 2)
+    return src_pts, dst_pts
+
+
+def matrix_signature(matrix):
+    return " ".join(f"{value:.17g}" for value in matrix.reshape(-1))
+
+
+def run_estimation(seed):
+    src_pts, dst_pts = load_tentatives()
+
+    start = perf_counter()
+    H, H_mask = pydegensac.findHomography(
+        src_pts,
+        dst_pts,
+        H_TH,
+        H_CONF,
+        H_ITERS,
+        seed=seed,
+    )
+    h_time = perf_counter() - start
+
+    start = perf_counter()
+    F, F_mask = pydegensac.findFundamentalMatrix(
+        src_pts,
+        dst_pts,
+        F_TH,
+        F_CONF,
+        F_ITERS,
+        enable_degeneracy_check=True,
+        seed=seed,
+    )
+    f_time = perf_counter() - start
+
+    H_mask = np.asarray(H_mask, dtype=bool)
+    F_mask = np.asarray(F_mask, dtype=bool)
+
+    return {
+        "seed": seed,
+        "num_tentatives": int(src_pts.shape[0]),
+        "homography": {
+            "runtime_sec": h_time,
+            "inliers": int(H_mask.sum()),
+            "matrix": np.asarray(H, dtype=np.float64).tolist(),
+            "mask": H_mask.astype(int).tolist(),
+            "signature": matrix_signature(np.asarray(H, dtype=np.float64)),
+        },
+        "fundamental": {
+            "runtime_sec": f_time,
+            "inliers": int(F_mask.sum()),
+            "matrix": np.asarray(F, dtype=np.float64).tolist(),
+            "mask": F_mask.astype(int).tolist(),
+            "signature": matrix_signature(np.asarray(F, dtype=np.float64)),
+        },
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    result = run_estimation(args.seed)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add explicit `seed` support to the public `pydegensac` homography and fundamental wrappers
- optimize the fundamental-matrix RANSAC scoring path without changing numerical outputs
- add reproducibility tests and fixed-seed benchmark helpers

## Verification
- `python setup.py build_ext --inplace`
- `PYTHONPATH=/Users/oldufo/dev/pydegensac/src pytest tests/test_import.py tests/test_seed_reproducibility.py`

## Notes
- benchmark helper scripts are included, but generated CSV/JSON benchmark outputs are not committed
- the F-path optimization was rechecked with fixed-seed A/B runs and preserved exact model signatures and inlier counts across the benchmark sweep